### PR TITLE
fix '/' not found error

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,8 +1,10 @@
 name: Alpha
 description: Alphs template for Jekyll
-baseurl: '/Alpha-Jekyll-Theme'
+baseurl: ''
 
 url: "http://localhost:4000"
 
 paginate: 10
 
+gems:
+  - jekyll-paginate


### PR DESCRIPTION
Updated `_config.yml` to fix '/' not found error. See [issue #5](https://github.com/CloudCannon/Alpha-Jekyll-Theme/issues/5)
